### PR TITLE
Log the response body in download_url

### DIFF
--- a/dshelpers.py
+++ b/dshelpers.py
@@ -123,6 +123,7 @@ def _download_without_backoff(url):
 
     L.info("Download {}".format(url))
     response = requests.get(url, timeout=_TIMEOUT)
+    L.debug('"{}"'.format(response.text))
     response.raise_for_status()
 
     return StringIO(response.content)


### PR DESCRIPTION
Otherwise it can be difficult to know the reason for an HTTP error (ie
403 Forbidden).

@scraperwiki/ds merge at will :)
