### PR TITLE
Get tags back in sync: upversion to 1.0.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from distutils.core import setup
 setup(name='dshelpers',
-      version='1.0.3',
+      version='1.0.4',
       description="Provides some helpers functions used by the ScraperWiki Data Services team.",
       long_description="Provides some helpers functions used by the ScraperWiki Data Services team.",
       classifiers=["Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
The tag for 1.0.3 is pointing at a version of the code which reports to be
1.0.2.

As far as I can see the best way to resolve is to upversion and add a new tag
(rather than overwrite the existing tag)
