### PR TITLE
Only log response text if needed

### DIFF
--- a/dshelpers.py
+++ b/dshelpers.py
@@ -145,6 +145,7 @@ def _download_without_backoff(url, as_file=True, **kwargs):
     response = requests.get(url, **kwargs_copy)
     
     if logging.getLogger().isEnabledFor(logging.DEBUG):
+        # This can be slow on large responses, due to chardet.
         L.debug('"{}"'.format(response.text))
 
     response.raise_for_status()

--- a/dshelpers.py
+++ b/dshelpers.py
@@ -143,8 +143,9 @@ def _download_without_backoff(url, as_file=True, **kwargs):
         kwargs_copy['headers'] = CaseInsensitiveDict({'user-agent': _USER_AGENT})
 
     response = requests.get(url, **kwargs_copy)
-
-    L.debug('"{}"'.format(response.text))
+    
+    if logging.getLogger().isEnabledFor(logging.DEBUG):
+        L.debug('"{}"'.format(response.text))
 
     response.raise_for_status()
 


### PR DESCRIPTION
Fixes #16.

Otherwise, this can result in `chardet` being used even if the debug statement isn't required which can be very slow on large responses (e.g. PDFs).