### PR TITLE
Remove --use-mirrors from pip command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ python:
   - "2.7"
   - "3.4"
 install:
-  - pip install -r requirements.txt --use-mirrors
+  - pip install -r requirements.txt
 script:
   - nosetests dshelpers.py


### PR DESCRIPTION
In .travis.yml: this isn't supported any more and causes build to fail.

Now Travis works again and we get a nice, green tick instead of a nasty
cross (to make *you* cross).