### PR TITLE
Check whether params and data are dicts

### DIFF
--- a/dshelpers.py
+++ b/dshelpers.py
@@ -143,7 +143,7 @@ def _download_without_backoff(url, as_file=True, method='GET', **kwargs):
     # 'cookies' and 'proxies' contributes to headers.
     # 'files' and 'json' contribute to data.
     for k in ['data', 'params']:
-        if k in kwargs:
+        if k in kwargs and isinstance(kwargs[k], dict):
             kwargs[k] = OrderedDict(sorted(kwargs[k].items()))
 
     kwargs_copy = dict(kwargs)


### PR DESCRIPTION
requests allows these to be other than dicts.

You can use e.g. a string as data, so only try and create an OrderedDict
from a dict.